### PR TITLE
workaround to etree.tostring uft8 problem

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-06-20 Jan Kotanski <jankotan@gmail.com>
+	* add a workaround for etree.tostring utf8 problem
+	* tagged as 3.4.1
+
 2022-06-09 Jan Kotanski <jankotan@gmail.com>
 	* add a step counter to the PYEVAL common block
 	* remove default mysql localhost

--- a/nxswriter/DataSources.py
+++ b/nxswriter/DataSources.py
@@ -95,7 +95,10 @@ class DataSource(object):
         :returns: xml content string
         :rtype: :obj:`str`
         """
-        xml = _tostr(et.tostring(node, encoding='utf8', method='xml'))
+        if sys.version_info > (3,):
+            xml = _tostr(et.tostring(node, encoding='unicode', method='xml'))
+        else:
+            xml = _tostr(et.tostring(node, encoding='utf8', method='xml'))
         if xml.startswith("<?xml version='1.0' encoding='utf8'?>"):
             xml = str(xml[38:])
         return xml

--- a/nxswriter/Release.py
+++ b/nxswriter/Release.py
@@ -21,4 +21,4 @@
 
 
 #: package version
-__version__ = "3.4.0"
+__version__ = "3.4.1"


### PR DESCRIPTION
It resolves a similar problem to #101 but triggered by nxswriter