### PR TITLE
Issue 122:  fix canfail mode for tango sources when proxy cannot be created 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
 2022-11-21 Jan Kotanski <jankotan@gmail.com>
+	* fix canfail mode for tango sources when proxy cannot be created
+	* tagged as 3.5.2
+
+2022-11-21 Jan Kotanski <jankotan@gmail.com>
 	* add empytunits metadata flag
 	* tagged as 3.5.1
 

--- a/nxswriter/Release.py
+++ b/nxswriter/Release.py
@@ -21,4 +21,4 @@
 
 
 #: package version
-__version__ = "3.5.1"
+__version__ = "3.5.2"

--- a/nxswriter/TangoSource.py
+++ b/nxswriter/TangoSource.py
@@ -239,8 +239,15 @@ class TangoSource(DataSource):
         elif device:
             self.device = "%s" % (edevice)
 
-        self.__proxy = ProxyTools.proxySetup(
-            self.device, streams=self._streams)
+        try:
+            self.__proxy = ProxyTools.proxySetup(
+                self.device, streams=self._streams)
+        except Exception:
+            if self._streams:
+                self._streams.error(
+                    "TangoSource::setup() - "
+                    "Cannot connect to: %s \ndefined by %s"
+                    % (self.device, xml), std=False)
 
         if not self.__proxy:
             if self._streams:

--- a/nxswriter/TangoSource.py
+++ b/nxswriter/TangoSource.py
@@ -247,8 +247,8 @@ class TangoSource(DataSource):
                     "Cannot connect to: %s \ndefined by %s"
                     % (self.device, xml), std=False)
 
-            raise DataSourceSetupError(
-                "Cannot connect to: %s \ndefined by %s" % (self.device, xml))
+            # raise DataSourceSetupError(
+            #     "Cannot connect to: %s \ndefined by %s" % (self.device, xml))
         if hostname and port and device and client:
             try:
                 host = self.__proxy.get_db_host().split(".")[0]

--- a/nxswriter/TangoSource.py
+++ b/nxswriter/TangoSource.py
@@ -51,13 +51,15 @@ class ProxyTools(object):
     """
 
     @classmethod
-    def proxySetup(cls, device, streams=None):
+    def proxySetup(cls, device, streams=None, maxcount=10):
         """ sets the Tango proxy up
 
         :param device: tango device
         :type device: :obj:`str`
         :param streams: tango-like steamset class
         :type streams: :class:`StreamSet` or :class:`tango.Device_4Impl`
+        :param maxcount: a number of tries
+        :type maxcount: :obj:`int`
         :returns: proxy if proxy is set up
         :rtype: :class:`tango.DeviceProxy`
         """
@@ -76,7 +78,7 @@ class ProxyTools(object):
                     std=False)
             raise
 
-        while not found and cnt < 1000:
+        while not found and cnt < maxcount:
             if cnt > 1:
                 time.sleep(0.01)
             try:
@@ -246,7 +248,7 @@ class TangoSource(DataSource):
                     "TangoSource::setup() - "
                     "Cannot connect to: %s \ndefined by %s"
                     % (self.device, xml), std=False)
-
+            # to make canfail works
             # raise DataSourceSetupError(
             #     "Cannot connect to: %s \ndefined by %s" % (self.device, xml))
         if hostname and port and device and client:

--- a/test/TangoSource_test.py
+++ b/test/TangoSource_test.py
@@ -410,6 +410,7 @@ class TangoSourceTest(unittest.TestCase):
 
         dname = 'Writer'
         device = 'stestp09/testss/s1r228'
+        wdevice = 'wtestp09/testss/s1r228'
         ctype = 'command'
         atype = 'attribute'
         host = self._dbhost
@@ -578,6 +579,25 @@ class TangoSourceTest(unittest.TestCase):
         except Exception:
             self.assertEqual(ds.client, "%s:%s/%s/%s" %
                              (host.split('.')[0], port, device, dname.lower()))
+
+        self.assertEqual(ds.group, None)
+        self.assertEqual(ds.member.memberType, atype)
+        self.assertEqual(ds.member.encoding, encoding)
+
+        ds.device = None
+        ds.client = None
+        ds.member.name = None
+        ds.member.memberType = None
+        ds.member.encoding = None
+        ds.setup("<datasource> <record name='%s'/> <device name='%s' "
+                 "encoding='%s' group='__CLIENT__'/> </datasource>" %
+                 (dname, wdevice, encoding))
+        self.assertEqual(ds.member.name, dname)
+        self.assertEqual(ds.device, wdevice)
+        try:
+            self.assertEqual(ds.client, None)
+        except Exception:
+            self.assertEqual(ds.client, None)
 
         self.assertEqual(ds.group, None)
         self.assertEqual(ds.member.memberType, atype)


### PR DESCRIPTION
It resolves #122 by fixing the canfail mode for tango sources when proxy cannot be created 